### PR TITLE
Suppress automatic generation of Default trait for array whose length is over 32

### DIFF
--- a/crates/anchor-idl/src/typedef.rs
+++ b/crates/anchor-idl/src/typedef.rs
@@ -102,7 +102,14 @@ pub fn get_type_properties(defs: &[IdlTypeDefinition], ty: &IdlType) -> FieldLis
             }
         }
         IdlType::Option(inner) => get_type_properties(defs, inner),
-        IdlType::Array(inner, _) => get_type_properties(defs, inner),
+        IdlType::Array(inner, len) => {
+          let inner = get_type_properties(defs, inner);
+          let can_derive_array_len = *len <= 32usize;
+          FieldListProperties {
+              can_copy: inner.can_copy,
+              can_derive_default: can_derive_array_len && inner.can_derive_default,
+          }
+        }
     }
 }
 

--- a/crates/anchor-idl/src/typedef.rs
+++ b/crates/anchor-idl/src/typedef.rs
@@ -31,7 +31,7 @@ pub fn get_type_list_properties(
         |acc, el| {
             let inner_props = get_type_properties(defs, el);
             let can_copy = acc.can_copy && inner_props.can_copy;
-            let can_derive_default = acc.can_copy && inner_props.can_derive_default;
+            let can_derive_default = acc.can_derive_default && inner_props.can_derive_default;
             FieldListProperties {
                 can_copy,
                 can_derive_default,


### PR DESCRIPTION
- Fix: invalid can_derive_default in get_type_list_properties
- Suppress automatic generation of Default trait for array whose length is over 32

Do not add derive(Default) to structures containing arrays longer than 32 because derive(Default) generates code that cannot be compiled.

This IDL contains TickArray account which has ticks field which is an array of size 88.
https://github.com/orca-so/whirlpools/blob/main/sdk/src/artifacts/whirlpool.json