### PR TITLE
Change Result type to ProgramResult for before v0.22.0

### DIFF
--- a/crates/anchor-generate-cpi-interface/src/lib.rs
+++ b/crates/anchor-generate-cpi-interface/src/lib.rs
@@ -28,7 +28,7 @@ use syn::parse_macro_input;
 /// # Examples
 ///
 /// ```
-/// anchor_generate_cpi_interface::generate_cpi_interface!(idl_path = "../../examples/govern-cpi/idl.json");
+/// anchor_generate_cpi_interface::generate_cpi_interface!(idl_path = "../../examples/govern-cpi/idl.json", target_anchor_version = "");
 /// declare_id!("GjphYQcbP1m3FuDyCTUJf2mUMxKPE3j6feWU1rxvC7Ps");
 /// # fn main() -> Result<()> {
 /// let _my_governor = GovernanceParameters {

--- a/crates/anchor-idl/Cargo.toml
+++ b/crates/anchor-idl/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro2 = "1"
 quote = "1"
 serde_json = "1.0.81"
 syn = { version = "1", features = ["full"] }
+semver = "1.0.13"
 
 [dev-dependencies]
 anchor-lang = "0.24.2"

--- a/crates/anchor-idl/src/instruction.rs
+++ b/crates/anchor-idl/src/instruction.rs
@@ -2,9 +2,13 @@ use anchor_syn::idl::IdlInstruction;
 use heck::{ToPascalCase, ToSnakeCase};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use semver::{Version, VersionReq};
 
 /// Generates a single instruction handler.
-pub fn generate_ix_handler(ix: &IdlInstruction) -> TokenStream {
+pub fn generate_ix_handler(
+    ix: &IdlInstruction,
+    target_anchor_version: &Version,
+) -> TokenStream {
     let ix_name = format_ident!("{}", ix.name.to_snake_case());
     let accounts_name = format_ident!("{}", ix.name.to_pascal_case());
 
@@ -21,18 +25,33 @@ pub fn generate_ix_handler(ix: &IdlInstruction) -> TokenStream {
         })
         .collect::<Vec<_>>();
 
-    quote! {
-        pub fn #ix_name(
-            _ctx: Context<#accounts_name>,
-            #(#args),*
-        ) -> Result<()> {
-            unimplemented!("This program is a wrapper for CPI.")
+    if VersionReq::parse(">=0.22.0").unwrap().matches(target_anchor_version) {
+        quote! {
+            pub fn #ix_name(
+                _ctx: Context<#accounts_name>,
+                #(#args),*
+            ) -> Result<()> {
+                unimplemented!("This program is a wrapper for CPI.")
+            }
+        }
+    }
+    else {
+        quote! {
+            pub fn #ix_name(
+                _ctx: Context<#accounts_name>,
+                #(#args),*
+            ) -> ProgramResult {
+                unimplemented!("This program is a wrapper for CPI.")
+            }
         }
     }
 }
 
 /// Generates instruction context structs.
-pub fn generate_ix_structs(ixs: &[IdlInstruction]) -> TokenStream {
+pub fn generate_ix_structs(
+    ixs: &[IdlInstruction],
+    _target_anchor_version: &Version,
+) -> TokenStream {
     let defs = ixs.iter().map(|ix| {
         let accounts_name = format_ident!("{}", ix.name.to_pascal_case());
 
@@ -54,8 +73,13 @@ pub fn generate_ix_structs(ixs: &[IdlInstruction]) -> TokenStream {
 }
 
 /// Generates all instruction handlers.
-pub fn generate_ix_handlers(ixs: &[IdlInstruction]) -> TokenStream {
-    let streams = ixs.iter().map(generate_ix_handler);
+pub fn generate_ix_handlers(
+    ixs: &[IdlInstruction],
+    target_anchor_version: &Version,
+) -> TokenStream {
+    let streams = ixs.iter().map(|ix|
+        generate_ix_handler(ix, target_anchor_version)
+    );
     quote! {
         #(#streams)*
     }

--- a/crates/anchor-idl/src/instruction.rs
+++ b/crates/anchor-idl/src/instruction.rs
@@ -5,10 +5,7 @@ use quote::{format_ident, quote};
 use semver::{Version, VersionReq};
 
 /// Generates a single instruction handler.
-pub fn generate_ix_handler(
-    ix: &IdlInstruction,
-    target_anchor_version: &Version,
-) -> TokenStream {
+pub fn generate_ix_handler(ix: &IdlInstruction, target_anchor_version: &Version) -> TokenStream {
     let ix_name = format_ident!("{}", ix.name.to_snake_case());
     let accounts_name = format_ident!("{}", ix.name.to_pascal_case());
 
@@ -25,7 +22,10 @@ pub fn generate_ix_handler(
         })
         .collect::<Vec<_>>();
 
-    if VersionReq::parse(">=0.22.0").unwrap().matches(target_anchor_version) {
+    if VersionReq::parse(">=0.22.0")
+        .unwrap()
+        .matches(target_anchor_version)
+    {
         quote! {
             pub fn #ix_name(
                 _ctx: Context<#accounts_name>,
@@ -34,8 +34,7 @@ pub fn generate_ix_handler(
                 unimplemented!("This program is a wrapper for CPI.")
             }
         }
-    }
-    else {
+    } else {
         quote! {
             pub fn #ix_name(
                 _ctx: Context<#accounts_name>,
@@ -77,9 +76,9 @@ pub fn generate_ix_handlers(
     ixs: &[IdlInstruction],
     target_anchor_version: &Version,
 ) -> TokenStream {
-    let streams = ixs.iter().map(|ix|
-        generate_ix_handler(ix, target_anchor_version)
-    );
+    let streams = ixs
+        .iter()
+        .map(|ix| generate_ix_handler(ix, target_anchor_version));
     quote! {
         #(#streams)*
     }

--- a/crates/anchor-idl/src/program.rs
+++ b/crates/anchor-idl/src/program.rs
@@ -62,7 +62,11 @@ impl GeneratorOptions {
             );
         });
 
-        Generator { idl, target_anchor_version, struct_opts }
+        Generator {
+            idl,
+            target_anchor_version,
+            struct_opts,
+        }
     }
 }
 
@@ -83,8 +87,14 @@ impl Generator {
         let idl = &self.idl;
         let program_name: Ident = format_ident!("{}", idl.name);
 
-        let accounts = generate_accounts(&idl.types, &idl.accounts, &self.target_anchor_version, &self.struct_opts);
-        let typedefs = generate_typedefs(&idl.types, &self.target_anchor_version, &self.struct_opts);
+        let accounts = generate_accounts(
+            &idl.types,
+            &idl.accounts,
+            &self.target_anchor_version,
+            &self.struct_opts,
+        );
+        let typedefs =
+            generate_typedefs(&idl.types, &self.target_anchor_version, &self.struct_opts);
         let ix_handlers = generate_ix_handlers(&idl.instructions, &self.target_anchor_version);
         let ix_structs = generate_ix_structs(&idl.instructions, &self.target_anchor_version);
 

--- a/crates/anchor-idl/src/state.rs
+++ b/crates/anchor-idl/src/state.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use anchor_syn::idl::{IdlField, IdlTypeDefinition};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use semver::Version;
 
 use crate::{generate_fields, get_field_list_properties, StructOpts};
 
@@ -67,6 +68,7 @@ pub fn generate_account(
 pub fn generate_accounts(
     typedefs: &[IdlTypeDefinition],
     account_defs: &[IdlTypeDefinition],
+    _target_anchor_version: &Version,
     struct_opts: &BTreeMap<String, StructOpts>,
 ) -> TokenStream {
     let defined = account_defs.iter().map(|def| match &def.ty {

--- a/crates/anchor-idl/src/typedef.rs
+++ b/crates/anchor-idl/src/typedef.rs
@@ -4,6 +4,7 @@ use anchor_syn::idl::{EnumFields, IdlEnumVariant, IdlField, IdlType, IdlTypeDefi
 use heck::ToSnakeCase;
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
+use semver::Version;
 
 use crate::StructOpts;
 
@@ -224,6 +225,7 @@ pub fn generate_enum(
 /// Generates structs and enums.
 pub fn generate_typedefs(
     typedefs: &[IdlTypeDefinition],
+    _target_anchor_version: &Version,
     struct_opts: &BTreeMap<String, StructOpts>,
 ) -> TokenStream {
     let defined = typedefs.iter().map(|def| {

--- a/examples/whirlpools/src/lib.rs
+++ b/examples/whirlpools/src/lib.rs
@@ -9,6 +9,7 @@
 
 anchor_gen::generate_cpi_interface!(
     idl_path = "idl.json",
+    target_anchor_version = "",
     zero_copy(TickArray, Tick),
     packed(TickArray, Tick)
 );


### PR DESCRIPTION
* add target_anchor_version option to change the generated code to match the anchor version

**Memo**
To use anchor-gen with anchor v0.20.x and v0.21.0, the return type of instruction must be ProgramResult (not Result<()>)
The type changed at v0.22.0 as breaking change.
https://github.com/coral-xyz/anchor/blob/master/CHANGELOG.md#breaking-3

**Implementation Consideration**
I thought about making it a feature of Cargo.toml, but since GeneratorOptions already existed, I implemented it as target_anchor_version.
By receiving the version, it is easier to respond to future breaking changes.