### PR TITLE
add compat-program-result feature

### DIFF
--- a/crates/anchor-gen/Cargo.toml
+++ b/crates/anchor-gen/Cargo.toml
@@ -13,6 +13,12 @@ readme = "../../README.md"
 name = "anchor_gen"
 path = "src/lib.rs"
 
+[features]
+compat-program-result = [
+  "anchor-generate-cpi-crate/compat-program-result",
+  "anchor-generate-cpi-interface/compat-program-result"
+]
+
 [dependencies]
 anchor-generate-cpi-crate = { version = "0.3.0", path = "../anchor-generate-cpi-crate" }
 anchor-generate-cpi-interface = { version = "0.3.0", path = "../anchor-generate-cpi-interface" }

--- a/crates/anchor-generate-cpi-crate/Cargo.toml
+++ b/crates/anchor-generate-cpi-crate/Cargo.toml
@@ -14,6 +14,9 @@ name = "anchor_generate_cpi_crate"
 path = "src/lib.rs"
 proc-macro = true
 
+[features]
+compat-program-result = ["anchor-idl/compat-program-result"]
+
 [dependencies]
 anchor-idl = { version = "0.3.0", path = "../anchor-idl" }
 syn = { version = "1", features = ["full"] }

--- a/crates/anchor-generate-cpi-interface/Cargo.toml
+++ b/crates/anchor-generate-cpi-interface/Cargo.toml
@@ -14,6 +14,9 @@ name = "anchor_generate_cpi_interface"
 path = "src/lib.rs"
 proc-macro = true
 
+[features]
+compat-program-result = ["anchor-idl/compat-program-result"]
+
 [dependencies]
 anchor-idl = { version = "0.3.0", path = "../anchor-idl" }
 darling = "0.14"

--- a/crates/anchor-idl/Cargo.toml
+++ b/crates/anchor-idl/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/saber-hq/anchor-gen"
 license = "Apache-2.0"
 keywords = ["solana", "anchor"]
 
+[features]
+compat-program-result = []
+
 [dependencies]
 anchor-syn = { version = "0.24.2", features = ["idl"] }
 darling = "0.14"

--- a/crates/anchor-idl/src/instruction.rs
+++ b/crates/anchor-idl/src/instruction.rs
@@ -21,12 +21,23 @@ pub fn generate_ix_handler(ix: &IdlInstruction) -> TokenStream {
         })
         .collect::<Vec<_>>();
 
-    quote! {
-        pub fn #ix_name(
-            _ctx: Context<#accounts_name>,
-            #(#args),*
-        ) -> Result<()> {
-            unimplemented!("This program is a wrapper for CPI.")
+    if cfg!(feature = "compat-program-result") {
+        quote! {
+            pub fn #ix_name(
+                _ctx: Context<#accounts_name>,
+                #(#args),*
+            ) -> ProgramResult {
+                unimplemented!("This program is a wrapper for CPI.")
+            }
+        }
+    } else {
+        quote! {
+            pub fn #ix_name(
+                _ctx: Context<#accounts_name>,
+                #(#args),*
+            ) -> Result<()> {
+                unimplemented!("This program is a wrapper for CPI.")
+            }
         }
     }
 }


### PR DESCRIPTION
To use anchor-gen with anchor v0.20.x and v0.21.0, the return type of instruction must be ProgramResult (not Result<()>)
The type changed at v0.22.0 as breaking change.
https://github.com/coral-xyz/anchor/blob/master/CHANGELOG.md#breaking-3

compat-program-result feature changes return type of instruction to ProgramResult.