### PR TITLE
Optional account fix

### DIFF
--- a/crates/anchor-idl/src/account.rs
+++ b/crates/anchor-idl/src/account.rs
@@ -19,10 +19,18 @@ pub fn generate_account_fields(
                 } else {
                     quote! {}
                 };
-                let ty = if info.signer {
-                    quote! { Signer<'info> }
-                } else {
-                    quote! { AccountInfo<'info> }
+                let ty = {
+                    let acc_type = if info.signer {
+                        quote! { Signer<'info> }
+                    } else {
+                        quote! { AccountInfo<'info> }
+                    };
+
+                    if info.optional {
+                        quote! { Option<#acc_type>}
+                    } else {
+                        acc_type
+                    }
                 };
                 quote! {
                    #annotation


### PR DESCRIPTION
Failed to generate interfaces for certain idls due to optional accounts. This PR properly handles optional account info and optional signer.